### PR TITLE
select 组件在value等于0时的错误

### DIFF
--- a/packages/vue-select/src/source/Select.vue
+++ b/packages/vue-select/src/source/Select.vue
@@ -658,7 +658,7 @@ export default {
      */
     setSelected (value) {
       this.clearAll()
-      if (value) {
+      if (value !== undefined && value !== null && value !== '') {
         if (this.multiple) {
           const list = Array.isArray(value) ? value : [value]
           list.forEach(v => this.selectedOptions.push(this.getOption(v)))


### PR DESCRIPTION
select 组件在value值等于0时，初始值无法显示。
并且在选择时需要多次选择value为0的label才能显示对应的label值。
发现是：“判断value值为空的条件太过简单导致”。